### PR TITLE
Allow any redis gem version > 4, < 6

### DIFF
--- a/cb2.gemspec
+++ b/cb2.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*.rb"] + Dir["Gemfile*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "redis", "~> 4"
+  s.add_dependency "redis", "> 4", "< 6"
   s.add_development_dependency "rake",    "> 0"
   s.add_development_dependency "rr",      "~> 1.1"
   s.add_development_dependency "rspec",   "~> 3.1"


### PR DESCRIPTION
To allow for the Redis gem version 5.x series.